### PR TITLE
[DONE] Prevent duplicate submission

### DIFF
--- a/tensorflix/config.py
+++ b/tensorflix/config.py
@@ -21,6 +21,7 @@ class Config(BaseSettings):
     service_ai_detector_url: str = "http://localhost:12002"
 
     # ─────────────────── MongoDB  ───────────────────
+    # Need to create Shared MongoDB Atlas Cluster and give its url to validators to replace the default
     mongodb_uri: str = Field(default="mongodb://localhost:27017/", env="MONGODB_URI")
 
     # ─────────────────── Derived helpers ────────────


### PR DESCRIPTION
- Adds a `unique_submissions` collection to track the first valid submission of any content.
- Subsequent submissions of the same content from other miners are now ignored.
- Centralized db using mongo atlas cluster.

**IMPORTANT:** For this to work, all validators on the subnet **must** configure their `MONGODB_URI` to point to the same shared database instance.