### PR TITLE
Re-enable Instagram platform support

### DIFF
--- a/tensorflix/config.py
+++ b/tensorflix/config.py
@@ -9,7 +9,7 @@ from pydantic_settings import BaseSettings
 class Config(BaseSettings):
     # ─────────────────── General ────────────────────
     netuid: int = 89
-    allowed_platforms: tuple[str] = ("youtube/video",)
+    allowed_platforms: tuple[str] = ("youtube/video", "instagram/post", "instagram/reel")
     submission_update_interval: int = Field(60 * 60 * 2, description="seconds")
     set_weights_interval: int = Field(60 * 20, description="seconds")
     max_int_weight: int = 65_535


### PR DESCRIPTION
## Summary
- Re-enable Instagram post and reel submissions by updating `allowed_platforms` in config.py
- All Instagram infrastructure (platform tracker, data types, Apify integration) remains fully functional
- Miners can now submit Instagram content alongside YouTube videos

## Changes
- Updated `tensorflix/config.py` to include `"instagram/post"` and `"instagram/reel"` in allowed platforms

## Requirements for Instagram submissions
- Content must include required signature in caption/description
- Must pass AI detection threshold (>30%)
- Requires valid Apify API key for platform tracker service
- Direct video URL must be accessible for AI analysis

## Test plan
- [ ] Verify config loads correctly with new platforms
- [ ] Test Instagram submission processing in validator
- [ ] Confirm engagement rate calculations work with Instagram metrics
- [ ] Validate Instagram content scoring and weight distribution

🤖 Generated with [Claude Code](https://claude.ai/code)